### PR TITLE
Block vote 8 v2

### DIFF
--- a/FHIR-us-pacio-adi.xml
+++ b/FHIR-us-pacio-adi.xml
@@ -9,7 +9,7 @@
 <artifact id="CapabilityStatement/adi" key="CapabilityStatement-adi" name="ADI CapabilityStatement"/>
 <artifact id="StructureDefinition/PADI-CareExperiencePreference" key="StructureDefinition-PADI-CareExperiencePreference" name="ADI Care Experience Preference"/>
 <artifact id="StructureDefinition/ADI-Composition-Header" key="StructureDefinition-ADI-Composition-Header" name="ADI Composition Header"/>
-<artifact id="ValueSet/PADIConsentActorRoleVS" key="ValueSet-PADIConsentActorRoleVS" name="ADI Consent Actor Role"/>
+<artifact deprecated="true" id="ValueSet/PADIConsentActorRoleVS" key="ValueSet-PADIConsentActorRoleVS" name="ADI Consent Actor Role"/>
 <artifact id="StructureDefinition/ADI-DocumentReference" key="StructureDefinition-ADI-DocumentReference" name="ADI Document Reference"/>
 <artifact id="StructureDefinition/PADI-DocumentationObservation" key="StructureDefinition-PADI-DocumentationObservation" name="ADI Documentation Observation"/>
 <artifact id="StructureDefinition/PADI-Goal" key="StructureDefinition-PADI-Goal" name="ADI Goal"/>
@@ -22,11 +22,11 @@
 <artifact id="StructureDefinition/PADI-PersonalPrioritiesOrganizer" key="StructureDefinition-PADI-PersonalPrioritiesOrganizer" name="ADI Personal Priorities Organizer"/>
 <artifact id="StructureDefinition/PADI-PreferenceCarePlan" key="StructureDefinition-PADI-PreferenceCarePlan" name="ADI Preference Care Plan"/>
 <artifact id="StructureDefinition/ADI-Provenance" key="StructureDefinition-ADI-Provenance" name="ADI Provenance"/>
-<artifact id="ValueSet/PADIAdvanceDirectiveCategoriesVS" key="ValueSet-PADIAdvanceDirectiveCategoriesVS" name="Advance Directive Categories"/>
+<artifact deprecated="true" id="ValueSet/PADIAdvanceDirectiveCategoriesVS" key="ValueSet-PADIAdvanceDirectiveCategoriesVS" name="Advance Directive Categories"/>
 <artifact id="StructureDefinition/padi-attestationInformation-extension" key="StructureDefinition-padi-attestationInformation-extension" name="Attestation Information"/>
 <artifact id="ValueSet/PADIAttesterRoleTypeVS" key="ValueSet-PADIAttesterRoleTypeVS" name="Attester Role"/>
 <artifact deprecated="true" id="StructureDefinition/padi-authorization-extension" key="StructureDefinition-padi-authorization-extension" name="Authorization"/>
-<artifact id="ValueSet/PADICareExperiencePreferencesVS" key="ValueSet-PADICareExperiencePreferencesVS" name="Care Experience Preferences"/>
+<artifact deprecated="true" id="ValueSet/PADICareExperiencePreferencesVS" key="ValueSet-PADICareExperiencePreferencesVS" name="Care Experience Preferences"/>
 <artifact id="StructureDefinition/padi-clause-extension" key="StructureDefinition-padi-clause-extension" name="Clause"/>
 <artifact id="ValueSet/PADIConsentTypeVS" key="ValueSet-PADIConsentTypeVS" name="Consent Type"/>
 <artifact id="StructureDefinition/padi-contextualValue-extension" key="StructureDefinition-padi-contextualValue-extension" name="Contextual Value"/>
@@ -105,7 +105,7 @@
 <artifact id="StructureDefinition/padi-informant-extension" key="StructureDefinition-padi-informant-extension" name="Informant"/>
 <artifact id="StructureDefinition/padi-informationRecipient-extension" key="StructureDefinition-padi-informationRecipient-extension" name="Information Recipient"/>
 <artifact id="ValueSet/PADIInterventionPreferencesVS" key="ValueSet-PADIInterventionPreferencesVS" name="Intervention Preferences"/>
-<artifact id="ValueSet/PADIInterventionPreferencesNarrativeVS" key="ValueSet-PADIInterventionPreferencesNarrativeVS" name="Intervention Preferences - Narrative"/>
+<artifact deprecated="true" id="ValueSet/PADIInterventionPreferencesNarrativeVS" key="ValueSet-PADIInterventionPreferencesNarrativeVS" name="Intervention Preferences - Narrative"/>
 <artifact id="ValueSet/PADIInterventionPreferencesOrdinalVS" key="ValueSet-PADIInterventionPreferencesOrdinalVS" name="Intervention Preferences - Ordinal"/>
 <artifact id="StructureDefinition/padi-jurisdiction-extension" key="StructureDefinition-padi-jurisdiction-extension" name="Jurisdiction"/>
 <artifact id="ValueSet/PADINoHealthcareAgentIncludedReasonVS" key="ValueSet-PADINoHealthcareAgentIncludedReasonVS" name="No Healthcare Agent Included Reason"/>

--- a/input/fsh/ADIHeaderProfile.fsh
+++ b/input/fsh/ADIHeaderProfile.fsh
@@ -36,7 +36,7 @@ Description: "This abstract profile defines constraints that represent common ad
 * language 1..1 MS
 * identifier 1..1 MS
 * type MS
-* type from PADIAdvanceDirectiveCategoriesVS (extensible)
+* type from $PADIAdvanceDirectiveCategories (extensible)
 
 * category 1..1 MS
 * subject 1..1 MS

--- a/input/fsh/ADIParticipantConsentProfile.fsh
+++ b/input/fsh/ADIParticipantConsentProfile.fsh
@@ -64,7 +64,7 @@ Description: "This profile is used to represent a consent for an advance directi
 * provision.actor.extension contains
     padi-clause-extension named ClauseExtension 0..*
     
-* provision.actor.role from PADIConsentActorRoleVS (required)
+* provision.actor.role from $PADIConsentActorRole (required)
 * provision.actor.reference only Reference(PADIParticipant)
 
 // [TODO] we need a valueset defined. Any candidates?

--- a/input/fsh/Aliases.fsh
+++ b/input/fsh/Aliases.fsh
@@ -39,5 +39,10 @@ Alias: $HL7RelatedPersonRelationshipType = http://hl7.org/fhir/ValueSet/relatedp
 Alias: $HL7AdataAbsentReason = http://terminology.hl7.org/CodeSystem/data-absent-reason
 
 Alias: $VSACClauseType = https://cts.nlm.nih.gov/fhir/res/ValueSet/2.16.840.1.113762.1.4.1115.14
-Alias: $VSACUponDeathPrefernces = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.11
+Alias: $VSACUponDeathPreferences = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.11
 
+// fix for FHIR-34838
+Alias: $PADIAdvanceDirectiveCategories = https://cts.nlm.nih.gov/fhir/res/ValueSet/2.16.840.1.113883.11.20.9.69.4
+Alias: $PADIInterventionPreferencesNarrative = https://cts.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1115.9
+Alias: $PADIConsentActorRole = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.35
+Alias: $PADICareExperiencePreferences = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.11

--- a/input/fsh/Aliases.fsh
+++ b/input/fsh/Aliases.fsh
@@ -43,6 +43,6 @@ Alias: $VSACUponDeathPreferences = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840
 
 // fix for FHIR-34838
 Alias: $PADIAdvanceDirectiveCategories = https://cts.nlm.nih.gov/fhir/res/ValueSet/2.16.840.1.113883.11.20.9.69.4
-Alias: $PADIInterventionPreferencesNarrative = https://cts.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1115.9
+Alias: $PADIInterventionPreferencesEndOfLifeGrouping = https://cts.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1115.9
 Alias: $PADIConsentActorRole = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.35
 Alias: $PADICareExperiencePreferences = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.11

--- a/input/fsh/CareExperiencePreferenceProfile.fsh
+++ b/input/fsh/CareExperiencePreferenceProfile.fsh
@@ -40,7 +40,7 @@ Description: "Care Experience Preference is a clinical statement that presents t
 * category ^slicing.description = "Slice based on $this value"
 
 * category 2..*
-* category from PADICareExperiencePreferencesVS (extensible)
+* category from $PADICareExperiencePreferences (extensible)
 * category contains
     type 1..1 MS 
     

--- a/input/fsh/ValueSets.fsh
+++ b/input/fsh/ValueSets.fsh
@@ -1,4 +1,5 @@
 
+/*
 ValueSet: PADIAdvanceDirectiveCategoriesVS
 Title: "Advance Directive Categories"
 Description: "Kinds of Advance Directives
@@ -10,9 +11,9 @@ This ValueSet is managed at the US National Library of Medicine (NLM) Value Set 
 * include $LOINC#86533-7 "Patient Living will"
 * include $LOINC#92664-2 "Power of attorney and Living will"
 * insert LOINCCopyrightNotice
+*/
 
-
-
+/*
 ValueSet: PADIConsentActorRoleVS
 Title: "ADI Consent Actor Role"
 Description: "This value set identifies the role the advance directive participant has, which could include: healthcare agent, proxy, or advisor roles that individuals commonly designate to empower surrogates to make medical treatment and care decisions when the individual is unable to effectively communicate with medical personnel or requires assistance with decision making.
@@ -24,7 +25,7 @@ This ValueSet is managed at the US National Library of Medicine (NLM) Value Set 
 * include $LOINC#75785-6 "Second alternate healthcare agent [Reported]"
 * include $LOINC#81343-6 "Healthcare agent advisor [Reported]"
 * insert LOINCCopyrightNotice
-
+*/
 
 ValueSet: PADIConsentTypeVS
 Title: "Consent Type"
@@ -56,7 +57,7 @@ This ValueSet is managed at the US National Library of Medicine (NLM) Value Set 
 * insert LOINCCopyrightNotice
 
 
-
+/*
 ValueSet: PADICareExperiencePreferencesVS
 Title: "Care Experience Preferences"
 Description: "This value set includes concepts representing an individual's care experience preferences at end of life which can be expressed by the individual in his or her advance care plan),(Data Element Scope: The intent of this value set is to identify personal care experience preferences that may be relevant and could be considered by clinicians when making a treatment/care plan for the person.
@@ -76,7 +77,7 @@ This ValueSet is managed at the US National Library of Medicine (NLM) Value Set 
 * include $LOINC#81366-7 "Unfinished business [Reported]"
 * include PADIGoalCategoryCS#care-experience-preference "Care experience preference"
 * insert LOINCCopyrightNotice
-
+*/
 
 
 
@@ -85,7 +86,7 @@ Title: "Intervention Preferences"
 Description: "Clinical Focus: This value set includes concepts representing an individual's intervention preferences which can be expressed by the individual in his or her advance care plan.),(Data Element Scope: The intent of this value set is to identify personal intervention preferences that may be relevant and could be considered by clinicians or any person or organization that is providing care, treatment, or performing any other type of act to or on behalf of the individual.)"
 * ^experimental = false
 * codes from valueset PADIInterventionPreferencesOrdinalVS
-* codes from valueset PADIInterventionPreferencesNarrativeVS
+* codes from valueset $PADIInterventionPreferencesNarrative
 * include PADIGoalCategoryCS#intervention-preference "Intervention preference"
 * insert LOINCCopyrightNotice
 
@@ -108,7 +109,7 @@ Description: "Clinical Focus: This value set includes concepts representing an i
 
 
 
-
+/*
 ValueSet: PADIInterventionPreferencesNarrativeVS
 Title: "Intervention Preferences - Narrative"
 Description: "Clinical Focus: This value set includes concepts representing an individual's intervention preferences which can be expressed by the individual in his or her advance care plan.),(Data Element Scope: The intent of this value set is to identify personal intervention preferences that may be relevant and could be considered by clinicians or any person or organization that is providing care, treatment, or performing any other type of act to or on behalf of the individual.)"
@@ -129,9 +130,9 @@ Description: "Clinical Focus: This value set includes concepts representing an i
 * include $LOINC#81376-6 "Mental health treatment preferences [Reported]"
 * include $LOINC#75779-9 "Thoughts on cardiopulmonary resuscitation (CPR) [Reported]"
 * include $LOINC#81353-5 "Thoughts on hastening death [Reported]"
-* codes from valueset $VSACUponDeathPrefernces
+* codes from valueset $VSACUponDeathPreferences
 * insert LOINCCopyrightNotice
-
+*/
 
 ValueSet: PADIHCADecisionsVS
 Title: "Healthcare Agent Decisions"

--- a/input/fsh/ValueSets.fsh
+++ b/input/fsh/ValueSets.fsh
@@ -85,13 +85,10 @@ ValueSet: PADIInterventionPreferencesVS
 Title: "Intervention Preferences"
 Description: "Clinical Focus: This value set includes concepts representing an individual's intervention preferences which can be expressed by the individual in his or her advance care plan.),(Data Element Scope: The intent of this value set is to identify personal intervention preferences that may be relevant and could be considered by clinicians or any person or organization that is providing care, treatment, or performing any other type of act to or on behalf of the individual.)"
 * ^experimental = false
-* codes from valueset PADIInterventionPreferencesOrdinalVS
-* codes from valueset $PADIInterventionPreferencesNarrative
+// * codes from valueset PADIInterventionPreferencesOrdinalVS
+* codes from valueset $PADIInterventionPreferencesEndOfLifeGrouping
 * include PADIGoalCategoryCS#intervention-preference "Intervention preference"
 * insert LOINCCopyrightNotice
-
-
-
 
 
 ValueSet: PADIInterventionPreferencesOrdinalVS
@@ -110,7 +107,7 @@ Description: "Clinical Focus: This value set includes concepts representing an i
 
 
 /*
-ValueSet: PADIInterventionPreferencesNarrativeVS
+ValueSet: PADIInterventionPreferencesEndOfLifeGroupingVS
 Title: "Intervention Preferences - Narrative"
 Description: "Clinical Focus: This value set includes concepts representing an individual's intervention preferences which can be expressed by the individual in his or her advance care plan.),(Data Element Scope: The intent of this value set is to identify personal intervention preferences that may be relevant and could be considered by clinicians or any person or organization that is providing care, treatment, or performing any other type of act to or on behalf of the individual.)"
 * ^experimental = false

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -112,17 +112,19 @@ Systems used to create and update patient-generated advance care plans through a
 </p>
 
 ### External drivers
+
+**Note:** The IG was initially developed during the beginning of the COVID-19 pandemic, before vaccines were available and many patients were put on ventilators at hospitals. The narrative below is meant to illustrate a situation where a patient in this case would want their advance directive in place.
+
+The aging population receiving healthcare in skilled nursing facilities and assisted living communities were under forced isolation to reduce the risk of contracting COVID-19. Additionally, due to the pandemic, those requiring medical care  experienced transitions of care without family or a personal advocate to accompany them in order to influence medical care or be at their side; concerns about the viral transmission potential associated with paper advance directive documents further complicate transitions of care. The impact created a sense of disempowerment, isolation, and a disconnection with the world they can no longer safely interact freely with.
+
 <p>
-The aging population receiving healthcare in skilled nursing facilities and assisted living communities have been under forced isolation to reduce the risk of contracting COVID-19. Additionally, due to the pandemic, those requiring medical care have experienced transitions of care without family or a personal advocate to accompany them in order to influence medical care or be at their side; concerns about the viral transmission potential associated with paper advance directive documents further complicate transitions of care. The impact is a sense of disempowerment, isolation, and a disconnection with the world they can no longer safely interact freely with.
+Never before had the availability of verifiable digital advance directive documents been so essential to delivering care.
 </p>
 <p>
-Never before has the availability of verifiable digital advance directive documents been so essential to delivering care.
+Providers understood that a person’s goals, preferences, and priorities for care were a critical element in a person-centered healthcare system.
 </p>
 <p>
-Providers understand that a person’s goals, preferences, and priorities for care are a critical element in a person-centered healthcare system.
-</p>
-<p>
-The role of technology and expanded adoption by the aging population, providers, and care teams has brought to the forefront the expectation of seamless accessibility of advance directive information.
+The role of technology and expanded adoption by the aging population, providers, and care teams brought to the forefront the expectation of seamless accessibility of advance directive information.
 </p>
 
 ### Audience/Expected Users

--- a/input/pagecontent/patient_stories_and_personas.md
+++ b/input/pagecontent/patient_stories_and_personas.md
@@ -4,7 +4,7 @@
 Angie has Sickle Cell Disease. She worries that if she contracts COVID-19 and becomes unable to communicate with medical personnel, they won't be familiar with her history and specific treatment needs. 
 
 
-She uses a consumer facing tool to create a digital advance directive or upload a scanned copy of her paper advance directive document. Her interoperable digital advance directive information is made available by being stored in a registry/repository/HIE/QHIN/EHR. 
+She uses a consumer facing tool to create a digital advance directive or upload a scanned copy of her paper advance directive document. This tool may any customer-facing application, including but not limited to an EHR or a specialized care application. Her interoperable digital advance directive information is made available by being stored in a registry/repository/HIE/QHIN/EHR.
 
 
 Angie shares her advance directive information with her medical proxy/healthcare agent and primary care physician so if either are contacted by a treating provider in an emergency, they can make her advance directive accessible to inform treatment.


### PR DESCRIPTION
Reapplied fixes for

- [FHIR-34835](https://jira.hl7.org/browse/FHIR-34835): The justification scenario is deeply problematic. 
- [FHIR-34838](https://jira.hl7.org/browse/FHIR-34838): Consider using VSAC ValueSets where they exist (
- [FHIR-35567](https://jira.hl7.org/browse/FHIR-35567): Defining URL should be anchored in THO not hl7.org/fhir. Only those with required binding to a 'code' data type should be anchored in hl7.fhir.org.7 
- [FHIR-34830](https://jira.hl7.org/browse/FHIR-34830): Clarification of Use Case

**Note:** There was a conflicting change with FHIR-34838 which stated to replace the ValueSet for [PADIInterventionPreferencesNarrative](https://build.fhir.org/ig/HL7/pacio-adi/ValueSet-PADIInterventionPreferencesNarrativeVS.html) to a VSAC URI and FHIR-35567 which requested to remove it altogether.

The following was done to resolve that conflict:

- I kept the OID 2.16.840.1.113762.1.4.1115.9 since the ballot resolution and vote was in May, after the March comment, and since it’s voted, it’s the one to apply.
- I assumed that in the ticket of FHIR-35567, Corey generally just wanted to ensure that we had VSAV URLs and not our own, not literally to keep all of them if they were not appropriate.
- I replaced the value set name from [PADIInterventionPreferencesNarrative](https://build.fhir.org/ig/HL7/pacio-adi/ValueSet-PADIInterventionPreferencesNarrativeVS.html) to PADIInterventionPreferencessEndOfLifeGrouping which is the actual value set name in VSAC for that OID.