### PR TITLE
aligned Guidance pages in menu and table of content

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -48,6 +48,7 @@ menu:
     Formal Specification: formal_specification.html
     Security, Privacy, and Consent: security_privacy_consent.html
     Signatures: signatures.html
+    Search Parameters: search_parameters.html
     Key Terms and Acronyms: key_terms_and_acronyms.html
   FHIR Artifacts:
     Profiles: artifacts.html#2


### PR DESCRIPTION
Added Search Parameter link to the Guidance menu and aligned the orders of the pages with the table of contents list.
I am investigating whether sushi-config.yaml can have expandable folders in the table of contents, but it appears on first glance that only one level of menu is supported. 

Also note that the FHIR Artifacts in the TOC will not match the FHIR artifacts list menu. It appears that this generation is fixed in code and listed alphabetically.