### PR TITLE
fix for FHIR-46153.

### DIFF
--- a/FHIR-us-pacio-adi.xml
+++ b/FHIR-us-pacio-adi.xml
@@ -10,8 +10,10 @@
 <artifact id="CapabilityStatement/adi" key="CapabilityStatement-adi" name="ADI CapabilityStatement"/>
 <artifact id="StructureDefinition/ADI-CareExperiencePreference" key="StructureDefinition-PADI-CareExperiencePreference" name="ADI Care Experience Preference"/>
 <artifact id="StructureDefinition/ADI-Composition-Header" key="StructureDefinition-ADI-Composition-Header" name="ADI Composition Header"/>
+<artifact id="ValueSet/ADICompositionStatusVS" key="ValueSet-ADICompositionStatusVS" name="ADI Composition Status"/>
 <artifact deprecated="true" id="ValueSet/PADIConsentActorRoleVS" key="ValueSet-PADIConsentActorRoleVS" name="ADI Consent Actor Role"/>
 <artifact id="StructureDefinition/ADI-DocumentReference" key="StructureDefinition-ADI-DocumentReference" name="ADI Document Reference"/>
+<artifact id="ValueSet/ADIDocumentReferenceStatusVS" key="ValueSet-ADIDocumentReferenceStatusVS" name="ADI Document Reference Status"/>
 <artifact id="ValueSet/ADIDocumentRevokeStatusVS" key="ValueSet-ADIDocumentRevokeStatusVS" name="ADI Document Revoke Status"/>
 <artifact id="StructureDefinition/ADI-DocumentationObservation" key="StructureDefinition-PADI-DocumentationObservation" name="ADI Documentation Observation"/>
 <artifact deprecated="true" id="StructureDefinition/PADI-Goal" key="StructureDefinition-PADI-Goal" name="ADI Goal"/>

--- a/input/fsh/ADIHeaderProfile.fsh
+++ b/input/fsh/ADIHeaderProfile.fsh
@@ -32,7 +32,7 @@ Description: "This abstract profile defines constraints that represent common ad
     adi-participant-extension named ParticipantExtension 0..* and
     adi-performer-extension named PerformerExtension 0..* and
     adi-clause-extension named ClauseExtension 0..* and
-    adi-document-revoke-status-extension named DocumentRevokeStatus 0..1 MS
+    adi-document-revoke-status-extension named ADIDocumentRevokeStatusVS 0..1 MS
 
 * language 1..1 MS
 * identifier 1..1 MS
@@ -53,6 +53,8 @@ Description: "This abstract profile defines constraints that represent common ad
 
 * custodian 1..1 MS
 * custodian only Reference ($USCoreOrganization)
+
+*  status from ADICompositionStatusVS (required) // fix for FHIR-46153
 
 * section.extension contains    
     adi-clause-extension named ClauseExtension 0..*

--- a/input/fsh/DocumentReferenceProfile.fsh
+++ b/input/fsh/DocumentReferenceProfile.fsh
@@ -5,8 +5,6 @@ Id: ADI-DocumentReference
 Title: "ADI Document Reference"
 Description: "This profile defines constraints that represent the information needed to register an advance directive information document on a FHIR server."
 
-// Is a last updated required?
-//* meta.lastUpdated 1..1 MS
 * identifier MS
 * status MS
 * type 1..1 MS
@@ -31,6 +29,11 @@ Description: "This profile defines constraints that represent the information ne
 * context.encounter MS
 * context.encounter only Reference ($USCoreEncounter)
 * context.period MS
+
+* docStatus from ADIDocumentReferenceStatusVS (required) // fix for FHIR-46153
+
+* extension contains
+    adi-document-revoke-status-extension named ADIDocumentRevokeStatusVS 0..1 MS
 
 // These are from the mapping document and are likely not the intended final short descriptions
 RuleSet: ADIDocumentReferenceShortDescriptions

--- a/input/fsh/ValueSets.fsh
+++ b/input/fsh/ValueSets.fsh
@@ -155,14 +155,32 @@ Description: "Codes indicating Categories of Portable Medical Orders."
 * include $HL7ConsentCategoryCodes#dnr "Do Not Resuscitate"
 * include $HL7ConsentCategoryCodes#polst "POLST"
 
-ValueSet: ADIDocumentRevokeStatusVS
-Title: "ADI Document Revoke Status"
-Description: "a document status backported from the FHIR R5 Composition status version which supports the revoked document use case."
+ValueSet: ADICompositionStatusVS
+Title: "ADI Composition Status"
+Description: "a document status backported from the FHIR R5 Composition status."
 * ^experimental = false
 // * codes from system $HL7CompositionStatusR5  // mlt: updated to the valueset for FHIR R5 composition status.
 * include $HL7CompositionStatusR5#preliminary
 * include $HL7CompositionStatusR5#final
 * include $HL7CompositionStatusR5#amended
+
+ValueSet: ADIDocumentReferenceStatusVS
+Title: "ADI Document Reference Status"
+Description: "a document status backported from the FHIR R5 Document Reference Status."
+* ^experimental = false
+// * codes from system $HL7CompositionStatusR5  // mlt: updated to the valueset for FHIR R5 composition status.
+* include $HL7CompositionStatusR5#current
+* include $HL7CompositionStatusR5#superceded
+* include $HL7CompositionStatusR5#entered-in-error
+
+ValueSet: ADIDocumentRevokeStatusVS
+Title: "ADI Document Revoke Status"
+Description: "a document status backported from the FHIR R5 Composition status version which supports the revoked document use case."
+* ^experimental = false
+// * codes from system $HL7CompositionStatusR5  // mlt: updated to the valueset for FHIR R5 composition status.
+* include $HL7CompositionStatusR5#cancelled
+* include $HL7CompositionStatusR5#entered-in-error
+* include $HL7CompositionStatusR5#deprecated
 
 /* ********** RuleSets *********/
 


### PR DESCRIPTION
Composition.status, DocumentReference.docStatus, and extensions of DocumentRevokeStatus for both Composition and DocumentReference.