### PR TITLE
reverted PMO Comp attester binding.

### DIFF
--- a/input/fsh/PMOCompositionProfile.fsh
+++ b/input/fsh/PMOCompositionProfile.fsh
@@ -59,7 +59,6 @@ LA46-8 Other
 //* category = $LOINC#81352-7	"Medical Order for Life-Sustaining Treatment, Physician Order for Life-Sustaining Treatment, or a similar medical order is in place [Reported]"
 
 * author only Reference($USCorePractitionerRole)
-* attester.party only Reference($USCorePatient or $USCorePractitionerRole or $USCorePractitioner or $USCoreOrganization)
 
 * type = $LOINC#93037-0 // "Portable medical order form"
 

--- a/input/pagecontent/content_type_overview.md
+++ b/input/pagecontent/content_type_overview.md
@@ -12,7 +12,7 @@ There is a very important distinction for the three types of ADI content that wi
 <table>
     <tr>
         <th width="50">&nbsp;</th>
-        <th colspan="2" style="background-color:#DEEBF7; border: 1px solid black; vertical-align: middle; padding: 5px"><p style="font-size: 14px;"><b>Type I: Person-Authored Advance Directive Information</b></p></th>
+        <th colspan="2" style="background-color:#DEEBF7; border: 1px solid black; vertical-align: middle; padding: 5px"><p style="font-size: 14px;"><b>Type 1: Person-Authored Advance Directive Information</b></p></th>
     </tr>
     <tr><td width="50">&nbsp;</td>
         <td width="25">&nbsp;</td>

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -12,7 +12,7 @@ This ADI implementation guide (IG) describes how to use existing HL7 FHIR® stan
 </p>
 
 <p>
-Advance healthcare directives can be categorized into <a href="content_type_overview.html#adi-content-types">three types of information</a>. The current version of this guide addresses Content Type I: Person-Authored Advance Directive Information and Content Type 3:  Portable Medical Orders for Life-Sustaining Treatment. Subsequent versions of this guide will address the other two types; Content Type 2: Encounter-Centric Patient Instructions (obligations and prohibitions).
+Advance healthcare directives can be categorized into <a href="content_type_overview.html#adi-content-types">three types of information</a>. The current version of this guide addresses Content Type 1: Person-Authored Advance Directive Information and Content Type 3:  Portable Medical Orders for Life-Sustaining Treatment. Subsequent versions of this guide will address the other two types; Content Type 2: Encounter-Centric Patient Instructions (obligations and prohibitions).
 </p>
 <p>
 Included in the content for this FHIR IG are person-authored advance directives and personal advance care plans which comprise Content Type 1, and also cover patient consent information attesting to their designation of a person, or persons, to serve as their healthcare agent. 

--- a/input/pagecontent/system_use_cases.md
+++ b/input/pagecontent/system_use_cases.md
@@ -3,7 +3,7 @@
 
 In ADI use cases, advance directive content created and updated will be represented using FHIR resources. The advance directives content is created and may be updated periodically by human actors.
 
-For Content Type I, Person-authored advance directive information, there may be multiple human actors involved; however, there will only be one author which is the patient. Other human actors may include the healthcare agent, alternate healthcare agents, witness, notary, provider, and data enterer.
+For Content Type 1, Person-authored advance directive information, there may be multiple human actors involved; however, there will only be one author which is the patient. Other human actors may include the healthcare agent, alternate healthcare agents, witness, notary, provider, and data enterer.
 
 <blockquote class="stu-note">
     <p>


### PR DESCRIPTION
Also applied fix for FHIR-44103 - Typo: The second sentence in the second paragraph should read “Content Type 1” instead of “ Content Type I”