### PR TITLE
Fix for FHIR-49808

### DIFF
--- a/input/fsh/PACPCompositionProfile.fsh
+++ b/input/fsh/PACPCompositionProfile.fsh
@@ -7,6 +7,7 @@ Description: "This profile encompasses information that makes up the author’s 
 * author only Reference($USCorePatient)
 * attester 1..* MS      // made required (FHIR-46446)
 * attester.party only Reference($USCorePatient or RelatedPerson)
+* attester.mode = #personal
 
 * section ^slicing.discriminator.type = #pattern 
 * section ^slicing.discriminator.path = "code"

--- a/input/fsh/PMOCompositionProfile.fsh
+++ b/input/fsh/PMOCompositionProfile.fsh
@@ -7,6 +7,7 @@ Description: "This profile encompasses information that makes up a practitioner'
 * author only Reference($USCorePractitionerRole)
 * attester 1..* MS     
 * attester.party only Reference($USCorePractitioner or $USCorePractitionerRole or RelatedPerson)
+* attester.mode = #professional
 
 * type = $LOINC#93037-0 // "Portable medical order form"
 
@@ -38,10 +39,10 @@ Description: "This profile encompasses information that makes up a practitioner'
 * section ^slicing.description = "Slice based on code"
 * section contains
     portable_medical_orders 1..1 MS and
-    completion_information 0..1 MS and 
-    administration_information 0..1 MS and
-    additional_documentation 0..1 MS and
-    witness_and_notary 0..1 MS
+    completion_information 0..1 and 
+    administration_information 0..1 and
+    additional_documentation 0..1 and
+    witness_and_notary 0..1
 
 // ******* Medical Orders Section ********
 * section[portable_medical_orders] ^short = "Portable Medical Orders"
@@ -114,7 +115,7 @@ Description: "This profile encompasses information that makes up a practitioner'
 * section[administration_information].entry ^slicing.description = "Slice based on $this value"
 
 * section[administration_information].entry contains
-    adi_personal_goal 0..* MS
+    adi_personal_goal 0..* 
 * section[administration_information].entry[adi_personal_goal] only Reference(ADIPersonalGoal)
 
 // ******* PMO Additional Documentation Section ********

--- a/input/pagecontent/StructureDefinition-ADI-PACPComposition-intro.md
+++ b/input/pagecontent/StructureDefinition-ADI-PACPComposition-intro.md
@@ -1,3 +1,5 @@
 This profile defines the requirements for communicating a Personal Advance Care Plan (PACP) using a Composition Resource. It is used to create a person-generated document which is authored by the subject of the document (the patient). It contains information about the person's goals, preferences, and priorities (GPPs) for care and treatment under certain future conditions.
 
 It is possible for a PACP composition to only contain textual information and not have any encoded entries. In this case, an implementer may populate the `section.text` element in place of a resource reference in the `section.entry` element.
+
+For a Patient-authored composition, the attester is set to *personal*.

--- a/input/pagecontent/StructureDefinition-ADI-PMOComposition-intro.md
+++ b/input/pagecontent/StructureDefinition-ADI-PMOComposition-intro.md
@@ -1,0 +1,5 @@
+This profile defines the requirements for communicating a Portable Medical Order (PMO) using a Composition Resource. It is used to create a provider-generated document which is authored in collaboration with the subject of the document (the patient). It contains information about the person's medical orders, goals, preferences, and priorities (GPPs) for care and treatment under certain future conditions.
+
+It is possible for a PMO composition to only contain textual information and not have any encoded entries. In this case, an implementer may populate the `section.text` element in place of a resource reference in the `section.entry` element.
+
+For a provider-authored composition, the attester is set to *professional*.


### PR DESCRIPTION
Constrains need to be added to the Composition Profiles to make the attester element a Key element.
- PMO Composition attester.mode set to #professional
- PACP Composition attester.mode set to #personal 
- Further guidance on its usage added to each profile description.