### PR TITLE
Fix for FHIR-50125 and FHIR-50126

### DIFF
--- a/FHIR-us-pacio-adi.xml
+++ b/FHIR-us-pacio-adi.xml
@@ -53,12 +53,12 @@
 <artifact id="StructureDefinition/ADI-PMOServiceRequest" key="StructureDefinition-ADI-PMOServiceRequest" name="ADI PMO ServiceRequest"/>
 <artifact deprecated="true" id="StructureDefinition/ADI-Participant" key="StructureDefinition-PADI-Participant" name="ADI Participant"/>
 <artifact deprecated="true" id="StructureDefinition/ADI-ParticipantConsent" key="StructureDefinition-PADI-ParticipantConsent" name="ADI Participant Consent"/>
+<artifact id="StructureDefinition/ADI-PersonalGoal" key="StructureDefinition-PADI-PersonalGoal" name="ADI Personal Goal"/>
 <artifact id="StructureDefinition/ADI-PersonalPrioritiesOrganizer" key="StructureDefinition-PADI-PersonalPrioritiesOrganizer" name="ADI Personal Priorities Organizer"/>
 <artifact id="StructureDefinition/ADI-Provenance" key="StructureDefinition-ADI-Provenance" name="ADI Provenance"/>
 <artifact id="StructureDefinition/ADI-CareExperiencePreference" key="StructureDefinition-PADI-CareExperiencePreference" name="ADI PtAuthored Care Experience Preference"/>
 <artifact id="StructureDefinition/ADI-PreferenceCarePlan" key="StructureDefinition-PADI-PreferenceCarePlan" name="ADI PtAuthored Care Plan"/>
 <artifact id="StructureDefinition/ADI-PACPComposition" key="StructureDefinition-PADI-PACPComposition" name="ADI PtAuthored Composition"/>
-<artifact id="StructureDefinition/ADI-PersonalGoal" key="StructureDefinition-PADI-PersonalGoal" name="ADI PtAuthored Personal Goal"/>
 <artifact id="StructureDefinition/ADI-PersonalInterventionPreference" key="StructureDefinition-PADI-PersonalInterventionPreference" name="ADI PtAuthored Personal Intervention Preference"/>
 <artifact id="CodeSystem/ADIRevokeStatusCS" key="CodeSystem-ADIRevokeStatusCS" name="ADI Revoke Status Code System"/>
 <artifact id="CodeSystem/adi-temp-cs" key="CodeSystem-adi-temp-cs" name="ADI Temporary Code System"/>

--- a/input/fsh/Aliases.fsh
+++ b/input/fsh/Aliases.fsh
@@ -69,6 +69,7 @@ Alias: $VSACADIAdditionalPMOProceduresGrouping = http://cts.nlm.nih.gov/fhir/Val
 Alias: $VSACADIMedicallyAssistedNutritionOrderOptions = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.35
 Alias: $VSACADIMedicallyAssistedNutritionOrderOptionsGrouping = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.36
 Alias: $VSACCardiopulmonaryResuscitationOrderOptions = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.28
+Alias: $HealthGoalsAtEndOfLifeGrouping = https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.7
 
 // Standard extension aliases
 Alias: $data-absent-reason = http://terminology.hl7.org/CodeSystem/data-absent-reason

--- a/input/fsh/PACPCompositionProfile.fsh
+++ b/input/fsh/PACPCompositionProfile.fsh
@@ -23,13 +23,13 @@ Description: "This profile encompasses information that makes up the author’s 
 * section ^slicing.ordered = false   // can be omitted, since false is the default
 * section ^slicing.description = "Slice based on $this value"
 * section contains
-    healthcare_agent 0..1 and
-    gpp_for_certain_health_condition 0..1 MS and
-    gpp_personal_care_experience 0..1 MS and
-    gpp_upon_death 0..1 MS and
-    additional_documentation 0..1 MS and
-    witness_and_notary 0..1 MS and
-    administrative_information 0..1 MS
+    healthcare_agent 1..1 MS and
+    gpp_for_certain_health_condition 0..1 and
+    gpp_personal_care_experience 0..1 and
+    gpp_upon_death 0..1 and
+    additional_documentation 0..1 and
+    witness_and_notary 0..1 and
+    administrative_information 0..1
 
 * section[healthcare_agent] ^short = "Healthcare agents, healthcare agent advisors, and consent regarding their roles, powers, and limitations"
 

--- a/input/fsh/PersonalGoal.fsh
+++ b/input/fsh/PersonalGoal.fsh
@@ -1,7 +1,7 @@
 Profile: ADIPersonalGoal
 Parent: $USCoreGoal
 Id: ADI-PersonalGoal
-Title: "ADI PtAuthored Personal Goal"
+Title: "ADI Personal Goal"
 Description: "This profile is a statement that presents the author's personal health and treatment goals that are pertinent when planning their care."
 
 * category ^slicing.discriminator.type = #value 
@@ -13,11 +13,12 @@ Description: "This profile is a statement that presents the author's personal he
 * category 1..*
 * category.text MS
 * category contains type 1..1 MS 
-* category[type] = $LOINC#87528-6
+* category[type] from $HealthGoalsAtEndOfLifeGrouping
 
 * text 1..1 MS
 
 * description 1..1 MS
+// * description from $PersonalGoalGrouping  # MLT_TO_ADD once the VSAC valueset is available.
 * description.extension contains
     adi-enclosedPrecondition-extension named EnclosedPreconditionExtension 0..1
 * description.extension[adi-enclosedPrecondition-extension] ^comment = "Contextual Value contains the components that make up the Actual Value for use by systems for rendering or other purposes. It must not include additional information."


### PR DESCRIPTION
Fix for FHIR-50125:
- set healthcare agent section to 1..1 MS.
- Also removed MS from all PMO Composition sections except for Medical Orders.

Also partial fix for **FHIR-50126**: ADI Personal Goal category type and description need further constraints:
- Changed profile title from ADI PtAuthored PersonalGoal to ADI-Personal Goal.
- Changed Goal.category:type to bind to https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.7


