### PR TITLE
Fixes for FHIR-40285 & PMOCPRServiceRequest profile

### DIFF
--- a/FHIR-us-pacio-adi.xml
+++ b/FHIR-us-pacio-adi.xml
@@ -62,6 +62,7 @@
 <artifact id="StructureDefinition/ADI-PersonalInterventionPreference" key="StructureDefinition-PADI-PersonalInterventionPreference" name="ADI PtAuthored Personal Intervention Preference"/>
 <artifact id="CodeSystem/ADIRevokeStatusCS" key="CodeSystem-ADIRevokeStatusCS" name="ADI Revoke Status Code System"/>
 <artifact id="CodeSystem/adi-temp-cs" key="CodeSystem-adi-temp-cs" name="ADI Temporary Code System"/>
+<artifact id="StructureDefinition/ADI-UponDeathPreferences" key="StructureDefinition-ADI-UponDeathPreferences" name="ADI Upon Death Preferences"/>
 <artifact id="StructureDefinition/ADI-Witness" key="StructureDefinition-ADI-Witness" name="ADI Witness"/>
 <artifact deprecated="true" id="ValueSet/PADIAdvanceDirectiveCategoriesVS" key="ValueSet-PADIAdvanceDirectiveCategoriesVS" name="Advance Directive Categories"/>
 <artifact deprecated="true" id="StructureDefinition/padi-attestationInformation-extension" key="StructureDefinition-padi-attestationInformation-extension" name="Attestation Information"/>

--- a/input/fsh/Aliases.fsh
+++ b/input/fsh/Aliases.fsh
@@ -69,7 +69,8 @@ Alias: $VSACADIAdditionalPMOProceduresGrouping = http://cts.nlm.nih.gov/fhir/Val
 Alias: $VSACADIMedicallyAssistedNutritionOrderOptions = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.35
 Alias: $VSACADIMedicallyAssistedNutritionOrderOptionsGrouping = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.36
 Alias: $VSACCardiopulmonaryResuscitationOrderOptions = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.28
-Alias: $HealthGoalsAtEndOfLifeGrouping = https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.7
+Alias: $HealthGoalsGrouping = https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.7
+Alias: $CardiopulmonaryResuscitationProceduresGrouping = https://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1115.31
 
 // Standard extension aliases
 Alias: $data-absent-reason = http://terminology.hl7.org/CodeSystem/data-absent-reason

--- a/input/fsh/Example_PMO_BetsySmith-Johnson.fsh
+++ b/input/fsh/Example_PMO_BetsySmith-Johnson.fsh
@@ -179,4 +179,5 @@ Usage: #example
 * doNotPerform = true
 * subject = Reference(Example-Smith-Johnson-Patient1)
 * requester = Reference(Example-Kyle-Anydoc-Practitioner)
+* code = $LOINC#LA33470-8
 * orderDetail = $LOINC#LA33470-8

--- a/input/fsh/PACPCompositionProfile.fsh
+++ b/input/fsh/PACPCompositionProfile.fsh
@@ -67,7 +67,7 @@ Description: "This profile encompasses information that makes up the author’s 
 * section[gpp_upon_death].code 1..1 
 * section[gpp_upon_death].code = $LOINC#81337-8
 * section[gpp_upon_death].entry 
-* section[gpp_upon_death].entry only Reference(ADIPersonalInterventionPreference or ADIPersonalPrioritiesOrganizer or ADIAutopsyObservation or ADIOrganDonationObservation or ADIPersonalGoal)
+* section[gpp_upon_death].entry only Reference(ADIPersonalInterventionPreference or ADIPersonalPrioritiesOrganizer or ADIAutopsyObservation or ADIOrganDonationObservation or ADIPersonalGoal or ADIUponDeathPreference)
 
 
 * section[additional_documentation] ^short = "Observations regarding the existence of other advance directive related information"

--- a/input/fsh/PMOCompositionProfile.fsh
+++ b/input/fsh/PMOCompositionProfile.fsh
@@ -41,6 +41,7 @@ Description: "This profile encompasses information that makes up a practitioner'
     portable_medical_orders 1..1 MS and
     completion_information 0..1 and 
     administration_information 0..1 and
+    gpp_upon_death 0..1 and
     additional_documentation 0..1 and
     witness_and_notary 0..1
 
@@ -117,6 +118,16 @@ Description: "This profile encompasses information that makes up a practitioner'
 * section[administration_information].entry contains
     adi_personal_goal 0..* 
 * section[administration_information].entry[adi_personal_goal] only Reference(ADIPersonalGoal)
+
+// ******* GPP Upon Death ************
+
+* section[gpp_upon_death] ^short = "Goals, preferences, and priorities upon death"
+* section[gpp_upon_death].title 1..1 MS
+* section[gpp_upon_death].code 1..1 
+* section[gpp_upon_death].code = $LOINC#81337-8
+* section[gpp_upon_death].entry 
+* section[gpp_upon_death].entry only Reference(ADIPersonalInterventionPreference or ADIPersonalPrioritiesOrganizer or ADIAutopsyObservation or ADIOrganDonationObservation or ADIPersonalGoal or ADIUponDeathPreference)
+
 
 // ******* PMO Additional Documentation Section ********
 

--- a/input/fsh/PMOServiceRequest.fsh
+++ b/input/fsh/PMOServiceRequest.fsh
@@ -46,7 +46,8 @@ Description: "This profile is used to represent a practitioner authored portable
 
 * ^experimental = false
 * category = $LOINC#100822-6 "Cardiopulmonary resuscitation orders"
-* code = $SNOMEDCT#89666000 "Cardiopulmonary resuscitation (procedure)" 
+* code 1..1 MS
+* code from $CardiopulmonaryResuscitationProceduresGrouping (extensible)
 * doNotPerform 0..1 MS
 * orderDetail 1..1 MS
 * orderDetail from $VSACCardiopulmonaryResuscitationOrderOptions (required) 

--- a/input/fsh/PersonalGoal.fsh
+++ b/input/fsh/PersonalGoal.fsh
@@ -13,7 +13,7 @@ Description: "This profile is a statement that presents the author's personal he
 * category 1..*
 * category.text MS
 * category contains type 1..1 MS 
-* category[type] from $HealthGoalsAtEndOfLifeGrouping
+* category[type] from $HealthGoalsGrouping
 
 * text 1..1 MS
 

--- a/input/fsh/UponDeathPreferences.fsh
+++ b/input/fsh/UponDeathPreferences.fsh
@@ -1,0 +1,19 @@
+Profile: ADIUponDeathPreference
+Parent: Observation
+Id: ADI-UponDeathPreferences
+Title: "ADI Upon Death Preferences"
+Description: "This profile is used to represent the author's thoughts about preferences upon death."
+
+* text 1..1 MS
+* status = #final
+
+* category = #care-experience-preference
+* code 1..1 MS
+* code from $VSACUponDeathPreferences (extensible)
+* code.text 
+* subject 1..1 MS
+* subject only Reference($USCorePatient)
+
+* value[x] 1..1 MS
+* value[x] only string
+

--- a/input/pagecontent/system_use_cases.md
+++ b/input/pagecontent/system_use_cases.md
@@ -7,7 +7,7 @@ For Content Type 1, Person-authored advance directive information, there may be 
 
 <blockquote class="stu-note">
     <p>
-    STU1 supports only Person-authored Advance Directives (ADI Content Type 1) documents. Future versions of this FHIR IG will address encounter-centric patient instructions, Content Type 2, and portable medical orders (such as DNRs or POLST/MOLST orders) for Content Type 3.
+    STU2 includes support for Person-authored Advance Directives (ADI Content Type 1) and portable medical orders (such as DNRs or POLST/MOLST orders) for Content Type 3 documents. Future versions of this FHIR IG will address encounter-centric patient instructions, Content Type 2..**TO DO: Revise wording on scope**.
     </p>
 </blockquote>
 


### PR DESCRIPTION
Created ADI Upon Death Preferences (Profile) where:
- Observation.code is bound to 2.16.840.1.113762.1.4.1115.15 (extensible)
- Observation.category = “care-experience-preference”
- added as entry to the gpp-upon-death section in PtAuthored Composition Observation.value is valueString with free text of whatever the patient’s death wishes are.

Also:
- renamed value set from "Health Goals At End Of Life Grouping to  Health Goals Grouping
- bound PMOCPRServiceRequest profile code to CardiopulmonaryResuscitationProceduresGrouping value set
- replaced System Use Case page with STU1 note to STU2 note.